### PR TITLE
Reposition repository as Minimal Express Starter Kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,51 @@
-# Node, Express, EJS Template, Body-Parser - Sample App
+# Minimal Express Starter Kit
 
-###### _In this sample app_, we're using <br>
+A lightweight starter kit for building server-rendered Node.js apps with Express and EJS.
 
- - Node.js [<img  src="https://cdn2.iconfinder.com/data/icons/nodejs-1/256/nodejs-256.png" width="4%">](https://nodejs.org/en/) 
- - Express [<img  src="https://raygun.com/images/language-template/tiles/languages/javascript.svg" width="3%">](http://expressjs.com/)
- - Embedded JavaScript templating (EJS) [<img  src="https://s3.amazonaws.com/ciranda/entities/1/440727418fa168f705ebf17432805c04f82227e2.png" width="9%">](http://ejs.co/)
- - Body-Parser [<img src="https://sitecore.myget.org/Content/images/packageDefaultIcon_npm.png" width="4%">](https://www.npmjs.com/package/body-parser)
+## What’s included
 
+- **Express** for routing and middleware
+- **EJS** for server-side templates
+- **Body-parser** for URL-encoded and JSON request payloads
+- **Static asset serving** from `public/`
+- **Example routes** for pages and API endpoints
 
+## Quick start
 
-<img  src="https://raw.githubusercontent.com/tborges/Node-Express-EJS-Template-Body-Parser/master/public/img/Node-Express-EJS-Template-Body-Parser-app.png"  width="100%">
-
-## Running Locally
-
-Make sure you have [Node.js](https://nodejs.org/en/) and [npm](https://docs.npmjs.com/) installed.
+Make sure you have [Node.js](https://nodejs.org/) and npm installed.
 
 ```sh
-git clone git@github.com:tborges/Node-Express-EJS-Template-Body-Parser.git # or clone your own fork
+git clone git@github.com:tborges/Node-Express-EJS-Template-Body-Parser.git
 cd Node-Express-EJS-Template-Body-Parser
 npm install
-node app.js
+npm start
 ```
 
-Feel free to fork, modify, and have fun with it. If you hit bugs, report issues on GitHub [here](https://github.com/tborges/Node-Express-EJS-Template-Body-Parser/issues). <img  src="http://www.smashingbuzz.com/wp-content/uploads/2011/12/Ant-moving-around.gif"  width="9%"><br>
-This sample app is available under the <a href='https://github.com/tborges/Node-Express-EJS-Template-Body-Parser/blob/master/LICENSE'>MIT License</a>.
+Open `http://localhost:3000`.
+
+## Project structure
+
+```txt
+.
+├── app.js
+├── controllers/
+│   ├── apiController.js
+│   └── htmlController.js
+├── public/
+│   ├── img/
+│   └── style.css
+└── views/
+    ├── index.ejs
+    └── person.ejs
+```
+
+## Available scripts
+
+- `npm start` — runs the app with `node app.js`
+- `npm test` — validates JavaScript syntax for core app files
+
+## Notes
+
+This repo is intentionally minimal so you can adapt it quickly for your own app or API.
+
+Licensed under the [MIT License](LICENSE).

--- a/package.json
+++ b/package.json
@@ -1,17 +1,18 @@
 {
-  "name": "course",
+  "name": "minimal-express-starter-kit",
   "version": "1.0.0",
-  "description": "",
-  "main": "node-course.js",
+  "description": "Minimal Express starter kit with EJS templates and body-parser examples",
+  "main": "app.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "node app.js",
+    "test": "node --check app.js && node --check controllers/htmlController.js && node --check controllers/apiController.js"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tborges/node-course.git"
   },
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/tborges/node-course/issues"
   },

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -4,7 +4,7 @@
 <script src="https://code.jquery.com/jquery-1.11.3.min.js" ></script>
     </head>
     <body>
-        <h1>Node, Express, EJS Template, Body-Parser</h1>
+        <h1>Minimal Express Starter Kit</h1>
         <ul style="display: flex;list-style-type: none; ">
             <li><a href="/">Home</a></li>
             <li><a href="/person/TypeYourNameHere">Person</a></li>
@@ -12,8 +12,8 @@
 
         <!-- body-parser -->
     <div class="form-content">
-        <center>We are using <code>body-parser</code> here.
-        <br>Submit this form to receive the <br>confirmation message.</center>
+        <center>This starter includes <code>body-parser</code> for handling form data.
+        <br>Submit this form to verify request parsing is wired up correctly.</center>
         <form method="POST" action="/person">
             First Name: <input type="text" id="firstname" name="firstname"/><br/>
             Last Name: <input type="text" id="lastname" name="lastname"/><br/>

--- a/views/person.ejs
+++ b/views/person.ejs
@@ -8,7 +8,7 @@
             </ul>
 
         <!-- <p>Copy and paste on your URL above &uarr; the following path: <code>http://localhost:3000/person/UserName?querystring=11223344556677889900</code></p> -->
-        <h1>How To Test This Route</h1>
+        <h1>Dynamic Route Example</h1>
 
         <ol>
             <li>Replace UserName with any value.</li>
@@ -16,13 +16,13 @@
             <li>Observe how both values are rendered dynamically.</li>
         </ol>
         
-        <h2>Example: This demonstrates Express route params and query parsing.</h2>
+        <h2>Example: Route params and query parsing in Express.</h2>
         <code>http://localhost:3000/person/redlight?querystring=12345</code>
         <p></p>
 
         <!-- EJS Embedded Javascript -->
         <div class="background">
-        <small>This page demonstrates how Express captures dynamic route parameters and query string values, then injects them into an EJS template for rendering.</small>
+        <small>This starter route captures URL params and query values, then renders them with EJS.</small>
         <p>Person: <%= ID %></p>
         <p>My QUERYSTRING is: <%= QUERYSTRING %></p>
         </div>


### PR DESCRIPTION
### Motivation
- Reframe the repository from a demo/sample into a concise, reusable starter for building server-rendered Node.js apps with Express and EJS.
- Surface quick-start instructions, a clear project layout, and simple scripts so newcomers can run and adapt the code quickly.

### Description
- Rewrote `README.md` to present the project as a Minimal Express Starter Kit with `Quick start`, `Project structure`, and `Available scripts` sections and updated usage instructions to recommend `npm start`.
- Updated `package.json` metadata: changed `name`, added `description`, set `main` to `app.js`, added `start` and `test` scripts, and set `license` to `MIT`.
- Updated user-facing text in `views/index.ejs` and `views/person.ejs` to reflect starter-kit messaging and clarify the purpose of the example routes and `body-parser` usage.
- No SKILL files from the repository were required or used to make these documentation and copy updates.

### Testing
- Ran `npm test` (which performs `node --check` on `app.js`, `controllers/htmlController.js`, and `controllers/apiController.js`) and it passed successfully.
