### PR TITLE
Pin minimatch to ^5.1.7 via package override and update lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -338,8 +338,8 @@
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.7.tgz",
       "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "dependencies": {
         "brace-expansion": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
     "body-parser": "^1.18.3",
     "ejs": "^3.1.7",
     "express": "^4.16.3"
+  },
+  "overrides": {
+    "minimatch": "^5.1.7"
   }
 }


### PR DESCRIPTION
### Motivation
- Ensure the nested `minimatch` dependency is upgraded to `5.1.7` (likely addressing a security or compatibility issue) by forcing a consistent resolved version.

### Description
- Added an `overrides` entry in `package.json` with `"minimatch": "^5.1.7"` and updated `package-lock.json` to reflect `minimatch` bump from `5.1.6` to `5.1.7` under `node_modules/filelist/node_modules/minimatch`.

### Testing
- Ran `npm test` (which runs `node --check app.js && node --check controllers/htmlController.js && node --check controllers/apiController.js`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f1906db28832eb679718eb7afb67f)